### PR TITLE
Add GIT_MERGE_AUTOEDIT=no to suppress merge commit editor

### DIFF
--- a/roles/symlinks/files/bash/exports
+++ b/roles/symlinks/files/bash/exports
@@ -115,6 +115,8 @@ export BASH_SILENCE_DEPRECATION_WARNING=1
 if [[ -t 0 ]]; then
   export GPG_TTY=$(tty)
 fi
+# git - accept auto-generated merge commit messages without opening editor
+export GIT_MERGE_AUTOEDIT=no
 
 # format `time` output in zsh
 export TIMEFMT=$'\nTIME NEEDED:\nreal\t%E\nuser\t%U\nsys\t%S'


### PR DESCRIPTION
Exports `GIT_MERGE_AUTOEDIT=no` so that auto-generated merge commit messages are accepted without opening the editor.